### PR TITLE
Pass CancellationToken to IsValidAsync(...)

### DIFF
--- a/src/AspNetCore.Authentication.Basic/BasicHandler.cs
+++ b/src/AspNetCore.Authentication.Basic/BasicHandler.cs
@@ -11,6 +11,7 @@ using System;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.Basic
@@ -97,7 +98,8 @@ namespace AspNetCore.Authentication.Basic
 				}
 
 				// Validate using the implementation of IBasicUserValidationService.
-				var hasValidationSucceeded = await ValidateUsingBasicUserValidationServiceAsync(credentials.Username, credentials.Password).ConfigureAwait(false);
+				var cancellationToken = Context.RequestAborted;
+                var hasValidationSucceeded = await ValidateUsingBasicUserValidationServiceAsync(credentials.Username, credentials.Password, cancellationToken).ConfigureAwait(false);
 				return hasValidationSucceeded
 					? await RaiseAndHandleAuthenticationSucceededAsync(credentials).ConfigureAwait(false)
 					: AuthenticateResult.Fail("Invalid username or password.");
@@ -211,7 +213,7 @@ namespace AspNetCore.Authentication.Basic
 #endif
 		}
 
-		private async Task<bool> ValidateUsingBasicUserValidationServiceAsync(string username, string password)
+		private async Task<bool> ValidateUsingBasicUserValidationServiceAsync(string username, string password, CancellationToken cancellationToken)
 		{
 			IBasicUserValidationService basicUserValidationService = null;
 			if (Options.BasicUserValidationServiceType != null)
@@ -226,7 +228,7 @@ namespace AspNetCore.Authentication.Basic
 
 			try
 			{
-				return await basicUserValidationService.IsValidAsync(username, password).ConfigureAwait(false);
+				return await basicUserValidationService.IsValidAsync(username, password, cancellationToken).ConfigureAwait(false);
 			}
 			finally
 			{

--- a/src/AspNetCore.Authentication.Basic/IBasicUserValidationService.cs
+++ b/src/AspNetCore.Authentication.Basic/IBasicUserValidationService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Mihir Dilip. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.Basic
@@ -15,7 +16,8 @@ namespace AspNetCore.Authentication.Basic
 		/// </summary>
 		/// <param name="username"></param>
 		/// <param name="password"></param>
+		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task<bool> IsValidAsync(string username, string password);
+		Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken);
 	}
 }

--- a/test/AspNetCore.Authentication.Basic.Tests/BasicExtensionsTests.cs
+++ b/test/AspNetCore.Authentication.Basic.Tests/BasicExtensionsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -314,7 +315,7 @@ namespace AspNetCore.Authentication.Basic.Tests
 
         private class MockUserValidationService : IBasicUserValidationService
         {
-            public Task<bool> IsValidAsync(string username, string password)
+            public Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
@@ -322,7 +323,7 @@ namespace AspNetCore.Authentication.Basic.Tests
 
         private class MockUserValidationService2 : IBasicUserValidationService
         {
-            public Task<bool> IsValidAsync(string username, string password)
+            public Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/test/AspNetCore.Authentication.Basic.Tests/BasicHandlerTests.cs
+++ b/test/AspNetCore.Authentication.Basic.Tests/BasicHandlerTests.cs
@@ -15,6 +15,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -598,7 +599,7 @@ namespace AspNetCore.Authentication.Basic.Tests
 
         private class FakeBasicUserValidationServiceLocal_1 : IBasicUserValidationService
         {
-            public Task<bool> IsValidAsync(string username, string password)
+            public Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken)
             {
 				return Task.FromResult(true);
             }
@@ -606,7 +607,7 @@ namespace AspNetCore.Authentication.Basic.Tests
 
 		private class FakeBasicUserValidationServiceLocal_2 : IBasicUserValidationService
 		{
-            public Task<bool> IsValidAsync(string username, string password)
+            public Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken)
             {
 				return Task.FromResult(true);
 			}

--- a/test/AspNetCore.Authentication.Basic.Tests/Infrastructure/FakeBasicUserValidationService.cs
+++ b/test/AspNetCore.Authentication.Basic.Tests/Infrastructure/FakeBasicUserValidationService.cs
@@ -7,13 +7,14 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNetCore.Authentication.Basic.Tests.Infrastructure
 {
     class FakeBasicUserValidationService : IBasicUserValidationService
     {
-        public Task<bool> IsValidAsync(string username, string password)
+        public Task<bool> IsValidAsync(string username, string password, CancellationToken cancellationToken)
         {
             var user = FakeUsers.Users.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) && u.Password.Equals(password, StringComparison.OrdinalIgnoreCase));
             if (user != null)


### PR DESCRIPTION
When there is a long running operation, this helps cancel it if the request is aborted. For example, a database query.